### PR TITLE
Add flake8 checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+# To be added once code is refactored: E501, W291, W293, F401
+select = W191, W391, E115, E117, E122, E124, E125, E225, E231, E301, E303, F403
+count = True
+max-complexity = 10
+max-line-length = 100
+statistics = True

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -16,7 +16,14 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Style
+      - name: Install style requirements
         run: |
           pip install -r requirements_style.txt --disable-pip-version-check
-          make
+
+      - name: Codespell
+        run: |
+          make codespell
+
+      - name: flake8
+        run: |
+          make flake8

--- a/Makefile
+++ b/Makefile
@@ -12,22 +12,26 @@ codespell:
 	@echo "Running codespell"
 	@codespell $(CODESPELL_DIRS) -S $(CODESPELL_SKIP) -I $(CODESPELL_IGNORE)
 
+flake8:
+	@echo "Running flake8"
+	@flake8 .
+
 pydocstyle:
 	@echo "Running pydocstyle"
-	@pydocstyle ansys.mapdl
+	@pydocstyle ansys.dpf.post
 
 doctest-modules:
 	@echo "Runnnig module doctesting"
-	pytest -v --doctest-modules ansys.mapdl
+	pytest -v --doctest-modules ansys.dpf.post
 
 coverage:
 	@echo "Running coverage"
-	@pytest -v --cov ansys.mapdl
+	@pytest -v --cov ansys.dpf.post
 
 coverage-xml:
 	@echo "Reporting XML coverage"
-	@pytest -v --cov ansys.mapdl --cov-report xml
+	@pytest -v --cov ansys.dpf.post --cov-report xml
 
 coverage-html:
 	@echo "Reporting HTML coverage"
-	@pytest -v --cov ansys.mapdl --cov-report html
+	@pytest -v --cov ansys.dpf.post --cov-report html

--- a/ansys/dpf/post/dpf_solution.py
+++ b/ansys/dpf/post/dpf_solution.py
@@ -64,7 +64,7 @@ class DpfSolution:
     
     def __str__(self):
         txt = '%s solution object.' % self._model.metadata.result_info.analysis_type.capitalize() +\
-        '\n\n\nData Sources\n------------------------------\n'
+              '\n\n\nData Sources\n------------------------------\n'
         ds_str = self._data_sources.__str__()
         txt += ds_str
         txt += "\n\n"
@@ -184,8 +184,7 @@ class DpfMecanicComplexSolution(DpfSolution):
         if (tfq_sup.complex_frequencies == None):
             return False
         return True
-    
-    
+
     def displacement(self, **kwargs):
         """Returns a displacement object from which it is possible to get ResultData.
         
@@ -272,8 +271,7 @@ class DpfThermalSolution(DpfSolution):
     def __init__(self, data_sources, model):
         super().__init__(data_sources, model)
         #self.misc = ThermalMisc(model, data_sources)
-        
-        
+
     def __str__(self):
         txt = super().__str__()
         txt += "\n"

--- a/ansys/dpf/post/electric_results.py
+++ b/ansys/dpf/post/electric_results.py
@@ -16,7 +16,6 @@ class ElectricField(Vector):
         if _AvailableKeywords.element_scoping in kwargs:
             raise Exception("Element scoping is not available with thermal/electric results.")
         self.definition._Definition__element_scoping_locked = True
-            
 
     def __str__(self):
         txt = super().__str__()

--- a/ansys/dpf/post/misc_results.py
+++ b/ansys/dpf/post/misc_results.py
@@ -127,7 +127,6 @@ class MecanicMisc(Misc):
         self._check_nodal_location(**kwargs)
         return self._get_result_data_function_of_operator("ModalBasis", self, self._data_sources, **kwargs)
     
-    
     #element nodal results (get result at nodes or at elements)
     def elemental_stress(self, **kwargs):
         """Returns a elemental_stress result data."""
@@ -339,7 +338,6 @@ class MecanicMisc(Misc):
         self._check_nodal_location(**kwargs)
         return self._get_result_data_function_of_operator("ENL_ELENG", self, self._data_sources, location="Nodal", **kwargs)
     
-    
     #element nodal result (here only elemental result given because the nodal one is given in nodal category)
     def elemental_force(self, **kwargs):
         """Returns a elemental_force result data."""
@@ -351,7 +349,6 @@ class MecanicMisc(Misc):
         """Returns a elemental_nodal_force result data."""
         self._check_elemnodal_location(**kwargs)
         return self._get_result_data_function_of_operator("ENF", self, self._data_sources, location="ElementalNodal", **kwargs)
-    
     
     #element results
     def elemental_contact_status(self, **kwargs):
@@ -438,7 +435,6 @@ class MecanicMisc(Misc):
         """Returns a elemental_thermal_dissipation_energy result data."""
         self._check_elemental_location(**kwargs)
         return self._get_result_data_function_of_operator("ENG_TH", self, self._data_sources, location="Elemental", **kwargs)
-
 
     #special results
     def von_mises_stress(self, **kwargs):

--- a/ansys/dpf/post/result_data.py
+++ b/ansys/dpf/post/result_data.py
@@ -53,8 +53,7 @@ class ResultData:
                  location, element_scoping, node_scoping, named_selection, time, 
                  grouping, phase, subresult, mapdl_grouping, set, time_scoping)
         self.result_fields_container = None
-             
-            
+        
     def __str__(self):
         self._evaluate_result()
         name = self.result_fields_container[0].name.split("_")
@@ -178,8 +177,7 @@ class ResultData:
         returns its result (output from pin 0).
         """
         return self._min_max(0).data[field_index]
-    
-    
+
     def _plot_contour_with_vtk_file(self):
         """Plot the contour result on its mesh support. The obtained figure depends on the 
         support (can be a meshed_region or a time_freq_support).
@@ -189,8 +187,7 @@ class ResultData:
         self._evaluate_result()
         pl = DpfPlotter(self._evaluator._model.metadata.meshed_region)
         pl._plot_contour_using_vtk_file(self.result_fields_container)
-        
-    
+
     def plot_contour(self, display_option: str = "time", option_id=1,
                      off_screen=None, notebook=None, **kwargs):
         """Plot the contour result on its mesh support.

--- a/ansys/dpf/post/result_evaluation.py
+++ b/ansys/dpf/post/result_evaluation.py
@@ -79,7 +79,7 @@ class ResultEvaluator:
             if (grouping == Grouping.by_material) or (grouping == Grouping.by_body):
                 scop_op.inputs.label1.connect("mat")
             elif(grouping == Grouping.by_el_shape):
-                 scop_op.inputs.label1.connect("elshape")            
+                scop_op.inputs.label1.connect("elshape")            
             else:
                 raise Exception("Grouping impossible. Use the keyword argument as: grouping = grouping.by_el_shape, grouping = grouping.by_material...")
             self._result_operator.inputs.mesh_scoping.connect(scop_op.outputs.mesh_scoping)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,14 +44,14 @@ release = __version__
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc',
-              'sphinx_gallery.gen_gallery',
-              'sphinx.ext.todo',
-              'sphinx.ext.napoleon',
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx_gallery.gen_gallery',
+    'sphinx.ext.todo',
+    'sphinx.ext.napoleon',
 ]
 
 autosummary_generate = True
-
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']
@@ -106,8 +106,6 @@ sphinx_gallery_conf = {
     #                         "from pyvista import set_plot_theme\n"
     #                         "set_plot_theme('document')"),
 }
-
-
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/examples/01-Different-analysis-types/02-modal-analysis.py
+++ b/examples/01-Different-analysis-types/02-modal-analysis.py
@@ -110,4 +110,3 @@ elastic_strain.num_fields
 ###############################################################################
 # **It is also possible to deal with plastic_strain and temperature this way.**
 # The result file must contain those results.
-

--- a/requirements_style.txt
+++ b/requirements_style.txt
@@ -1,3 +1,3 @@
 codespell==2.0.0
-
+flake8==3.9.2
 

--- a/tests/test_dpfresultwithkeywords.py
+++ b/tests/test_dpfresultwithkeywords.py
@@ -578,7 +578,7 @@ def test_time_scoping_keyword_verbose_api(plate_msup):
     result = post.load_solution(plate_msup)
     disp = result.misc.nodal_displacement()
     assert disp.num_fields == 1
-    disp1 = result.misc.nodal_displacement(time_scoping=[1,2,4])
+    disp1 = result.misc.nodal_displacement(time_scoping=[1, 2, 4])
     assert disp1.num_fields == 3
     assert disp1.result_fields_container.get_label_space(0) == {'time': 1}
     assert np.isclose(disp1.get_data_at_field(0)[40][2], -2.0115581116044217e-06)
@@ -603,7 +603,7 @@ def test_time_scoping_keyword(plate_msup):
     d = result.displacement()
     disp = d.vector
     assert disp.num_fields == 1
-    d1 = result.displacement(time_scoping=[1,2,4])
+    d1 = result.displacement(time_scoping=[1, 2, 4])
     disp1 = d1.vector
     assert disp1.num_fields == 3
     assert disp1.result_fields_container.get_label_space(0) == {'time': 1}

--- a/tests/test_electricanalysis.py
+++ b/tests/test_electricanalysis.py
@@ -136,7 +136,6 @@ def test_electricfield_set(rth_electric):
     assert np.isclose(s[0].data[23][1], 19.562952041625977)
 
 
-
 def test_electricpotential(rth_electric):
     solution = post.load_solution(rth_electric)
     assert solution._model.metadata.result_info.physics_type == _PhysicsType.thermal

--- a/tests/test_resultdata.py
+++ b/tests/test_resultdata.py
@@ -165,7 +165,7 @@ def test_min_data_at_field(allkindofcomplexity):
 def test_get_all_labels_verbose_api(modalallkindofcomplexity):
     result = post.load_solution(modalallkindofcomplexity)
     stress = result.misc.elemental_stress()
-    l = [{'elshape': 1, 'time': 1},{'elshape': 0, 'time': 1}]
+    l = [{'elshape': 1, 'time': 1}, {'elshape': 0, 'time': 1}]
     l_comp = stress.get_all_label_spaces()
     assert l == l_comp
 
@@ -174,7 +174,7 @@ def test_get_all_labels(modalallkindofcomplexity):
     result = post.load_solution(modalallkindofcomplexity)
     s = result.stress(location=post.locations.elemental)
     stress = s.tensor
-    l = [{'elshape': 1, 'time': 1},{'elshape': 0, 'time': 1}]
+    l = [{'elshape': 1, 'time': 1}, {'elshape': 0, 'time': 1}]
     l_comp = stress.get_all_label_spaces()
     assert l == l_comp
 

--- a/tests/test_resultobject.py
+++ b/tests/test_resultobject.py
@@ -317,7 +317,6 @@ def test_tensor_complex(complex_model):
     assert len(ppal3[0].data) == 4802
 
 
-
 def test_raise_displacement_elemental_location(allkindofcomplexity):
     solution = post.load_solution(allkindofcomplexity)
     with pytest.raises(errors.NodalLocationError):

--- a/tests/test_thermalanalysis.py
+++ b/tests/test_thermalanalysis.py
@@ -106,7 +106,6 @@ def test_steadystate_set(rth_steady_state):
     assert np.isclose(s[0].data[24], 30.387240610202973)
 
 
-
 def test_thermal_transient(rth_transient):
     solution = post.load_solution(rth_transient)
     assert solution._model.metadata.result_info.physics_type == _PhysicsType.thermal


### PR DESCRIPTION
This is the first PR to make the code PEP8 compliant. It addresses extra blank lines and other whitespaces issues, covering these flake8 directives: W191, W391, E115, E117, E122, E124, E125, E225, E231, E301, E303, F403. Descriptions for these error codes can be found [here](https://flake8.pycqa.org/en/latest/user/error-codes.html) and [here](https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes). Running flake8 is added as part of the style CI. 
